### PR TITLE
fix: champ_img 컬럼의 최대 크기를 LONGBLOB으로 늘리는 코드 작성

### DIFF
--- a/src/main/java/lbs/lbs/entity/ChampionImg.java
+++ b/src/main/java/lbs/lbs/entity/ChampionImg.java
@@ -16,6 +16,7 @@ public class ChampionImg {
     private String champ_name;
 
     @Lob
+    @Column(columnDefinition = "LONGBLOB")
     private byte[] champ_img;
 
 }


### PR DESCRIPTION
컬럼의 최대 크기를 늘려 사진이 들어갈수 있도록 한다.